### PR TITLE
Small grammatical change in docs 

### DIFF
--- a/ScalableWebApp.md
+++ b/ScalableWebApp.md
@@ -635,7 +635,7 @@ cached for 1 hour. We do this to keep the information in cache relevant
 but the right duration for the cache will vary for every scenario.
 
 > In this sample the Concerts are not editable. Remember that when you
-> use a cache you will want change cached data it whenever a user makes
+> use a cache you will want to change cached data whenever a user makes
 > an update. You can achieve this with an event driven system or by
 > ensuring that the cached data is only accessed directly from the
 > repository class that is responsible for handling the create and edit


### PR DESCRIPTION
Reading through tonight, looks like this issue may have resulted from a previous edit where some words stuck around that were meant to be deleted.  Just made a quick edit for clarity.