### PR TITLE
Set vnet integration and application routing in site config

### DIFF
--- a/infra/applicationinsights.bicep
+++ b/infra/applicationinsights.bicep
@@ -1242,4 +1242,3 @@ resource applicationInsightsDashboard 'Microsoft.Portal/dashboards@2020-09-01-pr
 }
 
 output APPLICATIONINSIGHTS_CONNECTION_STRING string = applicationInsights.properties.ConnectionString
-output APPLICATIONINSIGHTS_INSTRUMENTATION_KEY string = applicationInsights.properties.InstrumentationKey


### PR DESCRIPTION
This PR introduces the following changes:
- Removes WEBSITE_VNET_ROUTE_ALL application setting in favor of `vnetRouteAllEnabled` site config setting.  In doing so, application routing is set to false, as private routing is the default.
- Removes WEBSITE_DNS_SERVER as the default is 168.63.129.16.
- Establishes regional vnet integration through use of `virtualNetworkSubnetId` property on Microsoft.Web/sites resource.  In doing so, Microsoft.Web/sites/networkConfig resources are removed.
- Whitespace changes introduced by editor (VSCode with Azure Bicep extension).