### PR TITLE
Fixes intermittent deployment error: missing app settings

### DIFF
--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -213,6 +213,9 @@ resource web 'Microsoft.Web/sites@2021-03-01' = {
         }
       }
     }
+    dependsOn: [
+      appSettings
+    ]
   }
 }
 
@@ -284,6 +287,9 @@ resource api 'Microsoft.Web/sites@2021-01-15' = {
         }
       }
     }
+    dependsOn: [
+      appSettings
+    ]
   }
 }
 


### PR DESCRIPTION
Resolves #87 

We've identified an issue with the App Service deployment. There are intermittent reports of the configuration settings not being written correctly to the App Service that is deployed. This PR addresses that issue by changing the serialization of `Microsoft.Web/sites/config` that is sent to the resource provides. The `dependsOn` block that is added ensures that both the `logs` and `appSettings` sections are saved together.

- [x] Local test experience
- [x] Integration test experience