### PR TITLE
Address DevOps workflow failures

### DIFF
--- a/.github/workflows/scheduled-azure-dev.yml
+++ b/.github/workflows/scheduled-azure-dev.yml
@@ -80,7 +80,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/azure-dev-cli-apps:latest
+      image: mcr.microsoft.com/azure-dev-cli-apps:1.3.0
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/scheduled-azure-dev.yml
+++ b/.github/workflows/scheduled-azure-dev.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/azure-dev-cli-apps:latest
+      image: mcr.microsoft.com/azure-dev-cli-apps:1.3.0
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/scheduled-azure-teardown.yml
+++ b/.github/workflows/scheduled-azure-teardown.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/azure-dev-cli-apps:latest
+      image: mcr.microsoft.com/azure-dev-cli-apps:1.3.0
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Reverting the AZD version to (1.3.0) one that is approved for this version of the content.