### PR TITLE
Updated known issues with  'ERROR: Invalid value specified for property 'web' of resource 'Application'.'

### DIFF
--- a/infra/createAppRegistrations.sh
+++ b/infra/createAppRegistrations.sh
@@ -90,7 +90,9 @@ environmentName=${resourceGroupName:0:$locationOfHyphen-1}
 
 
 frontDoorProfileName=$(az resource list -g $resourceGroupName --query "[? kind=='frontdoor' ].name" -o tsv)
+echo "frontDoorProfileName=$frontDoorProfileName"
 frontEndWebAppHostName=$(az afd endpoint list -g $resourceGroupName --profile-name $frontDoorProfileName --query "[].hostName" -o tsv --only-show-errors)
+echo "frontEndWebAppHostName=$frontEndWebAppHostName"
 frontEndWebAppUri="https://$frontEndWebAppHostName"
 
 substring="-rg"

--- a/known-issues.md
+++ b/known-issues.md
@@ -47,3 +47,12 @@ The following topics are intended to help readers with our most commonly reporte
     When the `azd provision` command runs it creates a deployment resource in your subscription. You must delete this deployment before you can change the Azure region.
 
     > Please see the [teardown instructions](README.md#clean-up-azure-resources) to address this issue.
+
+* **Error: Invalid value specified for property 'web' of resource 'Application'**
+    This error most often happens when the user is running the 'createAppRegistrations.sh' file to create new app registrations and the region of user is different than the region of provisioned azure resources. For ex. the user from Canada is running this script on their local machine and the Azure region selected is East US.
+
+    > You may need to wait a bit longer (15-20 minutes) before running the below command 
+
+    ```bash
+    ./infra/createAppRegistrations.sh -g "$myEnvironmentName-rg"
+    ```


### PR DESCRIPTION
Hi,
I was just following the readme and mostly things were smooth until I encountered the below error: 'ERROR: Invalid value specified for property 'web' of resource 'Application'.'

![image](https://github.com/Azure/reliable-web-app-pattern-dotnet/assets/5859358/aa4978ad-56fd-445c-b96b-79ef7552dcb5)

It took a while to figure out that I just need to wait. 

After a while, it just worked fine. Updated the known issues with this details.

