### PR TITLE
Fix Broken Link in dev-containers.md

### DIFF
--- a/dev-containers.md
+++ b/dev-containers.md
@@ -25,4 +25,4 @@ The Visual Studio Code Dev Containers extension lets you use a Docker container 
     * ![screenshot dev container azd](./assets/devcontainers/devcontainers5.png)
     * ![screenshot dev container bicep](./assets/devcontainers/devcontainers6.png)
 1. Continue on deploying the environment as before.
-    * [Deploy solution](deploy-solution.md)
+    * [Steps to deploy the reference implementation](README.md#steps-to-deploy-the-reference-implementation)


### PR DESCRIPTION
## Why

From the Pull Request at #253 , I noticed that the ['Deploy solution' link](https://github.com/Azure/reliable-web-app-pattern-dotnet/blob/117e1a6e432a7a99cd880986f716ef68194e1858/dev-containers.md#L28) in dev-containers.md was broken. The original link pointed to https://github.com/Azure/reliable-web-app-pattern-dotnet/blob/117e1a6e432a7a99cd880986f716ef68194e1858/README.md#steps-to-deploy-the-reference-implementation. Therefore, I have updated the link destination.

## What
Fix the link
