### PR TITLE
ToLower produces highly inefficient SQL query that does not scale

### DIFF
--- a/src/Relecloud.Web.Api/Services/SqlDatabaseConcertRepository/SqlDatabaseConcertRepository.cs
+++ b/src/Relecloud.Web.Api/Services/SqlDatabaseConcertRepository/SqlDatabaseConcertRepository.cs
@@ -153,13 +153,13 @@ namespace Relecloud.Web.Api.Services.SqlDatabaseConcertRepository
             }
 
             var customer = await this.database.Customers
-                .FirstOrDefaultAsync(c => c.Email.ToLower() == newCustomer.Email.ToLower());
+                .FirstOrDefaultAsync(c => c.Email == newCustomer.Email);
             if (customer == null)
             {
                 customer = new Customer
                 {
                     Id = newCustomer.Id,
-                    Email = newCustomer.Email,
+                    Email = newCustomer.Email.ToLower(),
                     Name = newCustomer.Name,
                     Phone = newCustomer.Phone,
                 };


### PR DESCRIPTION
We have been using this for an internal AZ resiliency test and as an output of our testing and analysis we discovered that under load, this SQL query does not perform. You should avoid using .ToLower() in Entity Framework LINQ queries as it will manifest as the following:

`SELECT TOP (2) [c].[Id], [c].[Email], [c].[Name], [c].[Phone] FROM [Customers] AS [c] WHERE LOWER([c].[Email]) = LOWER('foo@acme.com')`

As you can see from the execution plan below there is a significant performance difference. We noticed this impact when we put the system under heavy load (~50k requests per hour) on an Azure SQL MI configured with Business Critical Standard-series (Gen 5) (128 GB, 8 vCores, Zone-redundant backup storage). 

![image](https://github.com/Azure/reliable-web-app-pattern-dotnet/assets/3155241/a623a730-aa37-4f2a-8789-d336432f9d95)
