### PR TITLE
Create bicep-audit for security best practice validation

### DIFF
--- a/.github/workflows/bicep-audit.yml
+++ b/.github/workflows/bicep-audit.yml
@@ -1,0 +1,35 @@
+name: Analyze bicep templates
+on:
+  push:
+    branches: 
+      - main
+    paths:
+      - "infra/**"
+  pull_request:
+    branches: 
+      - main
+    paths:
+      - "infra/**"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Microsoft Security DevOps Analysis
+        uses: microsoft/security-devops-action@preview
+        id: msdo
+        continue-on-error: true
+        with:
+          tools: templateanalyzer
+
+      - name: Upload alerts to Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: github.repository_owner == 'Azure-Samples'
+        with:
+          sarif_file: ${{ steps.msdo.outputs.sarifFile }}


### PR DESCRIPTION
This PR adds an extra workflow that is either triggered manually or whenever anyone changes the files in infra/

It scans the templates against the best practice rule list, primarily for security and adds the results to the GitHub Security tab. Exceptions can be fixed or dismissed with reasons.