### PR TITLE
Add support for managed identity for redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,3 +354,6 @@ MigrationBackup/
 
 **/Azure.LoadTest.Tool/publish/
 **/log*.txt
+
+# Shows up in the dev container
+.mono

--- a/infra/core/database/azure-cache-for-redis.bicep
+++ b/infra/core/database/azure-cache-for-redis.bicep
@@ -54,6 +54,9 @@ type RedisUser = {
 
   @description('The alias of the user')
   alias: string
+
+  @description('Specify name of built-in access policy to use as assignment.')
+  accessPolicy: 'Data Owner' | 'Data Contributor' | 'Data Reader'
 }
 
 // ========================================================================
@@ -115,14 +118,6 @@ param redisCacheCapacity int = 1
 @description('If set, the private endpoint settings for this resource')
 param privateEndpointSettings PrivateEndpointSettings?
 
-@description('Specify name of Built-In access policy to use as assignment.')
-@allowed([
-  'Data Owner'
-  'Data Contributor'
-  'Data Reader'
-])
-param builtInAccessPolicyName string = 'Data Reader'
-
 param users RedisUser[] = []
 
 // ========================================================================
@@ -149,10 +144,10 @@ resource cache 'Microsoft.Cache/redis@2023-08-01' = {
 
 @batchSize(1)
 resource redisCacheBuiltInAccessPolicyAssignment 'Microsoft.Cache/redis/accessPolicyAssignments@2023-08-01' = [for user in users: {
-  name: guid(resourceGroup().id, name, builtInAccessPolicyName, user.objectId)
+  name: guid(resourceGroup().id, name, user.accessPolicy, user.objectId)
   parent: cache
   properties: {
-    accessPolicyName: builtInAccessPolicyName
+    accessPolicyName: user.accessPolicy
     objectId: user.objectId
     objectIdAlias: user.alias
   }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -442,7 +442,6 @@ module application './modules/application-resources.bicep' = {
     frontDoorSettings: frontdoor.outputs.settings
 
     // Settings
-    principalId: principalId
     administratorUsername: administratorUsername
     databasePassword: databasePassword
     clientIpAddress: clientIpAddress
@@ -473,7 +472,6 @@ module application2 './modules/application-resources.bicep' =  if (isMultiLocati
     databasePassword: databasePassword
     clientIpAddress: clientIpAddress
     useCommonAppServicePlan: willDeployCommonAppServicePlan
-    principalId: principalId
   }
   dependsOn: [
     resourceGroups2

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -442,6 +442,7 @@ module application './modules/application-resources.bicep' = {
     frontDoorSettings: frontdoor.outputs.settings
 
     // Settings
+    principalId: principalId
     administratorUsername: administratorUsername
     databasePassword: databasePassword
     clientIpAddress: clientIpAddress
@@ -472,6 +473,7 @@ module application2 './modules/application-resources.bicep' =  if (isMultiLocati
     databasePassword: databasePassword
     clientIpAddress: clientIpAddress
     useCommonAppServicePlan: willDeployCommonAppServicePlan
+    principalId: principalId
   }
   dependsOn: [
     resourceGroups2
@@ -492,11 +494,7 @@ module applicationPostConfiguration './modules/application-post-config.bicep' = 
     keyVaultName: isNetworkIsolated? hubNetwork.outputs.key_vault_name : application.outputs.key_vault_name
     kvResourceGroupName: isNetworkIsolated? resourceGroups.outputs.hub_resource_group_name : resourceGroups.outputs.application_resource_group_name
     readerIdentities: union(application.outputs.service_managed_identities, defaultDeploymentSettings.isMultiLocationDeployment ? application2.outputs.service_managed_identities : [])
-    redisCacheNamePrimary: application.outputs.redis_cache_name
-    redisCacheNameSecondary: isMultiLocationDeployment ? application2.outputs.redis_cache_name : application.outputs.redis_cache_name
     resourceNames: naming.outputs.resourceNames
-    applicationResourceGroupNamePrimary: resourceGroups.outputs.application_resource_group_name
-    applicationResourceGroupNameSecondary: isMultiLocationDeployment ? resourceGroups2.outputs.application_resource_group_name : ''
   }
 }
 

--- a/infra/modules/application-redis.bicep
+++ b/infra/modules/application-redis.bicep
@@ -76,6 +76,9 @@ type RedisUser = {
 
   @description('The alias of the user')
   alias: string
+
+  @description('Specify name of built-in access policy to use as assignment.')
+  accessPolicy: 'Data Owner' | 'Data Contributor' | 'Data Reader'
 }
 
 // ========================================================================
@@ -145,12 +148,11 @@ module redis '../core/database/azure-cache-for-redis.bicep' = {
         }
       : null
 
-    builtInAccessPolicyName: 'Data Owner'
     users: users
   }
 }
 
-resource redis_config 'Microsoft.AppConfiguration/configurationStores/keyValues@2021-10-01-preview' = {
+resource redis_config 'Microsoft.AppConfiguration/configurationStores/keyValues@2023-03-01' = {
   parent: configStore
   name: 'App:RedisCache:ConnectionString'
   properties: {

--- a/infra/modules/application-redis.bicep
+++ b/infra/modules/application-redis.bicep
@@ -1,0 +1,161 @@
+targetScope = 'resourceGroup'
+
+/*
+** An App Service running on a App Service Plan
+** Copyright (C) 2023 Microsoft, Inc.
+** All Rights Reserved
+**
+***************************************************************************
+*/
+
+// ========================================================================
+// USER-DEFINED TYPES
+// ========================================================================
+
+// From: infra/types/DeploymentSettings.bicep
+@description('Type that describes the global deployment settings')
+type DeploymentSettings = {
+  @description('If \'true\', then two regional deployments will be performed.')
+  isMultiLocationDeployment: bool
+
+  @description('If \'true\', use production SKUs and settings.')
+  isProduction: bool
+
+  @description('If \'true\', isolate the workload in a virtual network.')
+  isNetworkIsolated: bool
+
+  @description('If \'false\', then this is a multi-location deployment for the second location.')
+  isPrimaryLocation: bool
+
+  @description('The Azure region to host resources')
+  location: string
+
+  @description('The name of the workload.')
+  name: string
+
+  @description('The ID of the principal that is being used to deploy resources.')
+  principalId: string
+
+  @description('The type of the \'principalId\' property.')
+  principalType: 'ServicePrincipal' | 'User'
+
+  @description('The token to use for naming resources.  This should be unique to the deployment.')
+  resourceToken: string
+
+  @description('The development stage for this application')
+  stage: 'dev' | 'prod'
+
+  @description('The common tags that should be used for all created resources')
+  tags: object
+
+  @description('The common tags that should be used for all workload resources')
+  workloadTags: object
+}
+
+// From: infra/types/DiagnosticSettings.bicep
+@description('The diagnostic settings for a resource')
+type DiagnosticSettings = {
+  @description('The number of days to retain log data.')
+  logRetentionInDays: int
+
+  @description('The number of days to retain metric data.')
+  metricRetentionInDays: int
+
+  @description('If true, enable diagnostic logging.')
+  enableLogs: bool
+
+  @description('If true, enable metrics logging.')
+  enableMetrics: bool
+}
+
+// From: infra/types/RedisUser.bicep
+@description('Type describing the user for redis.')
+type RedisUser = {
+  @description('The object id of the user.')
+  objectId: string
+
+  @description('The alias of the user')
+  alias: string
+}
+
+// ========================================================================
+// PARAMETERS
+// ========================================================================
+
+@description('The deployment settings to use for this deployment.')
+param deploymentSettings DeploymentSettings
+
+@description('The diagnostic settings to use for logging and metrics.')
+param diagnosticSettings DiagnosticSettings
+
+@description('The resource names for the resources to be created.')
+param resourceNames object
+
+@description('The tags to associate with this resource.')
+param tags object = {}
+
+@description('The users to be added to the redis instance.')
+param users RedisUser[]
+
+@description('When deploying a hub, the private endpoints will need this parameter to specify the resource group that holds the Private DNS zones')
+param dnsResourceGroupName string = ''
+
+/*
+** Dependencies
+*/
+@description('The name of the App Configuration store to configure for configuration.')
+param appConfigurationName string
+
+@description('The ID of the Log Analytics workspace to use for diagnostics and logging.')
+param logAnalyticsWorkspaceId string = ''
+
+@description('The list of subnets that are used for linking into the virtual network if using network isolation.')
+param subnets object = {}
+
+// ========================================================================
+// EXISTING RESOURCES
+// ========================================================================
+
+resource configStore 'Microsoft.AppConfiguration/configurationStores@2021-10-01-preview' existing = {
+  name: appConfigurationName
+}
+
+// ========================================================================
+// AZURE MODULES
+// ========================================================================
+
+module redis '../core/database/azure-cache-for-redis.bicep' = {
+  name: 'application-redis-db-${deploymentSettings.resourceToken}'
+  params: {
+    name: resourceNames.redis
+    location: deploymentSettings.location
+    diagnosticSettings: diagnosticSettings
+    logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
+    // vault provided by Hub resource group when network isolated
+    redisCacheSku: deploymentSettings.isProduction ? 'Standard' : 'Basic'
+    redisCacheFamily: 'C'
+    redisCacheCapacity: deploymentSettings.isProduction ? 1 : 0
+
+    privateEndpointSettings: deploymentSettings.isNetworkIsolated
+      ? {
+          dnsResourceGroupName: dnsResourceGroupName
+          name: resourceNames.redisPrivateEndpoint
+          resourceGroupName: resourceNames.spokeResourceGroup
+          subnetId: subnets[resourceNames.spokePrivateEndpointSubnet].id
+        }
+      : null
+
+    builtInAccessPolicyName: 'Data Owner'
+    users: users
+  }
+}
+
+resource redis_config 'Microsoft.AppConfiguration/configurationStores/keyValues@2021-10-01-preview' = {
+  parent: configStore
+  name: 'App:RedisCache:ConnectionString'
+  properties: {
+    value: redis.outputs.connection_string
+    tags: tags
+  }
+  dependsOn: [redis]
+}

--- a/infra/modules/application-resources.bicep
+++ b/infra/modules/application-resources.bicep
@@ -133,9 +133,6 @@ param clientIpAddress string = ''
 @description('If true, use a common App Service Plan.  If false, use a separate App Service Plan per App Service.')
 param useCommonAppServicePlan bool
 
-@description('The principal id of the user running the deployment')
-param principalId string
-
 // ========================================================================
 // VARIABLES
 // ========================================================================
@@ -467,14 +464,19 @@ module redis './application-redis.bicep' = {
     logAnalyticsWorkspaceId: logAnalyticsWorkspaceId
     subnets: subnets
     tags: moduleTags
-    users: [
+    users: deploymentSettings.principalId == null ? [
+      {
+       alias: appManagedIdentity.name
+       objectId: appManagedIdentity.outputs.principal_id 
+      }
+    ] : [
       {
        alias: appManagedIdentity.name
        objectId: appManagedIdentity.outputs.principal_id 
       }
       {
-        alias: principalId
-        objectId: principalId
+        alias: deploymentSettings.principalId
+        objectId: deploymentSettings.principalId
       }
     ]
   }

--- a/infra/modules/application-resources.bicep
+++ b/infra/modules/application-resources.bicep
@@ -466,15 +466,15 @@ module redis './application-redis.bicep' = {
     tags: moduleTags
     users: deploymentSettings.principalId == null ? [
       {
-       alias: ownerManagedIdentity.name
-       objectId: ownerManagedIdentity.outputs.principal_id
-       accessPolicy: 'Data Contributor'
+        alias: ownerManagedIdentity.name
+        objectId: ownerManagedIdentity.outputs.principal_id
+        accessPolicy: 'Data Contributor'
       }
     ] : [
       {
-       alias: ownerManagedIdentity.name
-       objectId: ownerManagedIdentity.outputs.principal_id
-       accessPolicy: 'Data Contributor'
+        alias: ownerManagedIdentity.name
+        objectId: ownerManagedIdentity.outputs.principal_id
+        accessPolicy: 'Data Contributor'
       }
       {
         alias: deploymentSettings.principalId

--- a/infra/modules/application-resources.bicep
+++ b/infra/modules/application-resources.bicep
@@ -467,16 +467,19 @@ module redis './application-redis.bicep' = {
     users: deploymentSettings.principalId == null ? [
       {
        alias: appManagedIdentity.name
-       objectId: appManagedIdentity.outputs.principal_id 
+       objectId: appManagedIdentity.outputs.principal_id
+       accessPolicy: 'Data Owner'
       }
     ] : [
       {
        alias: appManagedIdentity.name
-       objectId: appManagedIdentity.outputs.principal_id 
+       objectId: appManagedIdentity.outputs.principal_id
+       accessPolicy: 'Data Owner'
       }
       {
         alias: deploymentSettings.principalId
         objectId: deploymentSettings.principalId
+        accessPolicy: 'Data Owner'
       }
     ]
   }

--- a/infra/modules/application-resources.bicep
+++ b/infra/modules/application-resources.bicep
@@ -468,18 +468,18 @@ module redis './application-redis.bicep' = {
       {
        alias: ownerManagedIdentity.name
        objectId: ownerManagedIdentity.outputs.principal_id
-       accessPolicy: 'Data Owner'
+       accessPolicy: 'Data Contributor'
       }
     ] : [
       {
        alias: ownerManagedIdentity.name
        objectId: ownerManagedIdentity.outputs.principal_id
-       accessPolicy: 'Data Owner'
+       accessPolicy: 'Data Contributor'
       }
       {
         alias: deploymentSettings.principalId
         objectId: deploymentSettings.principalId
-        accessPolicy: 'Data Owner'
+        accessPolicy: 'Data Contributor'
       }
     ]
   }

--- a/infra/modules/application-resources.bicep
+++ b/infra/modules/application-resources.bicep
@@ -466,14 +466,14 @@ module redis './application-redis.bicep' = {
     tags: moduleTags
     users: deploymentSettings.principalId == null ? [
       {
-       alias: appManagedIdentity.name
-       objectId: appManagedIdentity.outputs.principal_id
+       alias: ownerManagedIdentity.name
+       objectId: ownerManagedIdentity.outputs.principal_id
        accessPolicy: 'Data Owner'
       }
     ] : [
       {
-       alias: appManagedIdentity.name
-       objectId: appManagedIdentity.outputs.principal_id
+       alias: ownerManagedIdentity.name
+       objectId: ownerManagedIdentity.outputs.principal_id
        accessPolicy: 'Data Owner'
       }
       {

--- a/infra/types/RedisUser.bicep
+++ b/infra/types/RedisUser.bicep
@@ -1,0 +1,9 @@
+// From: infra/types/RedisUser.bicep
+@description('Type describing the user for redis.')
+type RedisUser = {
+  @description('The object id of the user.')
+  objectId: string
+
+  @description('The alias of the user')
+  alias: string
+}

--- a/infra/types/RedisUser.bicep
+++ b/infra/types/RedisUser.bicep
@@ -6,4 +6,7 @@ type RedisUser = {
 
   @description('The alias of the user')
   alias: string
+
+  @description('Specify name of built-in access policy to use as assignment.')
+  accessPolicy: 'Data Owner' | 'Data Contributor' | 'Data Reader'
 }

--- a/src/Relecloud.Web.CallCenter.Api/AzureExtensions.cs
+++ b/src/Relecloud.Web.CallCenter.Api/AzureExtensions.cs
@@ -1,0 +1,56 @@
+﻿using Azure.Core;
+using Azure.Identity;
+using StackExchange.Redis;
+using System.IdentityModel.Tokens.Jwt;
+
+namespace Relecloud.Web
+{
+    internal static class AzureExtensions
+    {
+        public static TokenCredential GetAzureTokenCredential(this WebApplicationBuilder builder) => builder.Configuration["App:AzureCredentialType"] switch
+        {
+            "AzureCLI" => new AzureCliCredential(),
+            "Environment" => new EnvironmentCredential(),
+            "ManagedIdentity" => new ManagedIdentityCredential(builder.Configuration["AZURE_CLIENT_ID"]),
+            "VisualStudio" => new VisualStudioCredential(),
+            "VisualStudioCode" => new VisualStudioCodeCredential(),
+            _ => new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = builder.Configuration["AZURE_CLIENT_ID"] }),
+        };
+
+        public static void AddAzureStackExchangeRedisCache(this IServiceCollection services, string redisCacheName, TokenCredential token)
+        {
+            // We prefer not to get async results this way, but there's no easy way to handle this at the moment
+            var configurationOptions = ConfigureAzureRedisAsync(redisCacheName, token).GetAwaiter().GetResult();
+
+            services.AddStackExchangeRedisCache(options =>
+            {
+                options.ConfigurationOptions = configurationOptions;
+            });
+        }
+
+        /// <summary>
+        /// Connects Azure Redis to use managed identiy.
+        /// </summary>
+        /// <remarks>
+        /// Currently, the service requires the name of the identity which is also the object id of the identity. We can retrieve it from the supplied credential so we do that here.
+        /// For the current discussion on this, see https://github.com/Azure/Microsoft.Azure.StackExchangeRedis/issues/17
+        /// </remarks>
+        private static async Task<ConfigurationOptions> ConfigureAzureRedisAsync(string connectionString, TokenCredential credential)
+        {
+            var options = ConfigurationOptions.Parse(connectionString);
+
+            // Use a placeholder principalId before we can extract
+            await options.ConfigureForAzureAsync(new() { PrincipalId = string.Empty, TokenCredential = credential });
+
+            // Extract actual principal id
+            var jwt = options.Defaults.Password;
+            var handler = new JwtSecurityTokenHandler();
+            var token = handler.ReadJwtToken(jwt);
+            var clientid = token.Payload["oid"].ToString();
+
+            options.User = clientid;
+
+            return options;
+        }
+    }
+}

--- a/src/Relecloud.Web.CallCenter.Api/Relecloud.Web.CallCenter.Api.csproj
+++ b/src/Relecloud.Web.CallCenter.Api/Relecloud.Web.CallCenter.Api.csproj
@@ -12,7 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.1" />
-		<PackageReference Include="Azure.Identity" Version="1.10.2" />
+		<PackageReference Include="Azure.Identity" Version="1.11.2" />
 		<PackageReference Include="Azure.Search.Documents" Version="11.4.0-beta.5" />
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.13.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.12" />
@@ -30,6 +30,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Azure.StackExchangeRedis" Version="2.0.0" />
 		<PackageReference Include="Microsoft.Identity.Web" Version="1.23.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/Relecloud.Web.CallCenter/Program.cs
+++ b/src/Relecloud.Web.CallCenter/Program.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All Rights Reserved.
 // Licensed under the MIT License.
 
-using Azure.Identity;
 using Microsoft.IdentityModel.Logging;
 using Relecloud.Web;
 
 var builder = WebApplication.CreateBuilder(args);
+
+var azureCredential = builder.GetAzureTokenCredential();
 
 var hasRequiredConfigSettings = !string.IsNullOrEmpty(builder.Configuration["App:AppConfig:Uri"]);
 
@@ -14,12 +15,12 @@ if (hasRequiredConfigSettings)
     builder.Configuration.AddAzureAppConfiguration(options =>
     {
         options
-            .Connect(new Uri(builder.Configuration["App:AppConfig:Uri"]), new DefaultAzureCredential())
+            .Connect(new Uri(builder.Configuration["App:AppConfig:Uri"]), azureCredential)
             .ConfigureKeyVault(kv =>
             {
                 // Some of the values coming from Azure App Configuration are stored Key Vault, use
                 // the managed identity of this host for the authentication.
-                kv.SetCredential(new DefaultAzureCredential());
+                kv.SetCredential(azureCredential);
             });
     });
 }
@@ -36,7 +37,7 @@ if (builder.Environment.IsDevelopment())
 
 // Apps migrating to 6.0 don't need to use the new minimal hosting model
 // https://learn.microsoft.com/en-us/aspnet/core/migration/50-to-60?view=aspnetcore-6.0&tabs=visual-studio#apps-migrating-to-60-dont-need-to-use-the-new-minimal-hosting-model
-var startup = new Startup(builder.Configuration);
+var startup = new Startup(builder.Configuration, azureCredential);
 
 // Add services to the container.
 if (hasRequiredConfigSettings)

--- a/src/Relecloud.Web.CallCenter/Relecloud.Web.CallCenter.csproj
+++ b/src/Relecloud.Web.CallCenter/Relecloud.Web.CallCenter.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -8,7 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <Compile Include="..\Relecloud.Web.CallCenter.Api\AzureExtensions.cs" Link="AzureExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.11.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="3.0.0">
@@ -16,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Azure.StackExchangeRedis" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.1" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.25.1" />
     <PackageReference Include="Microsoft.Identity.Web.MicrosoftGraph" Version="1.25.1" />


### PR DESCRIPTION
This change does the following:

- Adds a new application module for the redis resource which handles adding the passwordless connection string to the app configuration
- Updates to a newer redis bicep module that allows using entra
- Adds a parameter to add entra users to the redis service
- Refactors the registration of the redis distributed cache to use managed identity