### PR TITLE
Add secure attribute and verify that it works

### DIFF
--- a/infra/core/security/key-vault-secrets.bicep
+++ b/infra/core/security/key-vault-secrets.bicep
@@ -15,6 +15,7 @@ targetScope = 'resourceGroup'
 // ========================================================================
 
 @description('The form of each Key Vault Secret to store.')
+@secure()
 type KeyVaultSecret = {
   @description('The key for the secret')
   key: string


### PR DESCRIPTION
I validated that adding this attribute prevents the secrets from showing up in non-secure contexts.

Before:

![before](https://github.com/Azure/reliable-web-app-pattern-dotnet/assets/583206/ef64c7ab-2e77-4bcd-9464-39c8964e66ef)

After:

![after](https://github.com/Azure/reliable-web-app-pattern-dotnet/assets/583206/07b82236-f584-4864-b4af-e2c3a9c53a12)

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1914249