### PR TITLE
Use azureadmin for vm name

### DIFF
--- a/infra/core/compute/ubuntu-jumpbox.bicep
+++ b/infra/core/compute/ubuntu-jumpbox.bicep
@@ -29,7 +29,7 @@ param name string
 param computerLinuxName string?
 
 @description('Username for the Virtual Machine. NOTE: this is not saved anywhere as Entra is used to manage SSH logins once created.')
-param adminUsername string = newGuid()
+param adminUsername string = 'azureadmin'
 
 @description('Password for admin. NOTE: this is not saved anywhere as Entra is used to manage SSH logins once created.')
 @secure()


### PR DESCRIPTION
Since we didn't need the username of the vm, it was suggested to use a uid for it. However, this breaks - it still expects the azureadmin name somewhere. For now, reverting so things will work