### PR TITLE
Update projects to .NET 8

### DIFF
--- a/src/Relecloud.Web.CallCenter.Api/Controllers/ImageController.cs
+++ b/src/Relecloud.Web.CallCenter.Api/Controllers/ImageController.cs
@@ -27,7 +27,7 @@ namespace Relecloud.Web.Controllers
         {
             try
             {
-                if (imageName.IsNullOrEmpty())
+                if (string.IsNullOrEmpty(imageName))
                 {
                     return BadRequest();
                 }

--- a/src/Relecloud.Web.CallCenter.Api/Program.cs
+++ b/src/Relecloud.Web.CallCenter.Api/Program.cs
@@ -11,12 +11,12 @@ var azureCredential = builder.GetAzureTokenCredential();
 
 var hasRequiredConfigSettings = !string.IsNullOrEmpty(builder.Configuration["App:AppConfig:Uri"]);
 
-if (hasRequiredConfigSettings)
+if (hasRequiredConfigSettings) 
 {
     builder.Configuration.AddAzureAppConfiguration(options =>
     {
         options
-            .Connect(new Uri(builder.Configuration["App:AppConfig:Uri"]), azureCredential)
+            .Connect(new Uri(builder.Configuration["App:AppConfig:Uri"]!), azureCredential)
             .UseFeatureFlags() // Feature flags will be loaded and, by default, refreshed every 30 seconds
             .ConfigureKeyVault(kv =>
             {

--- a/src/Relecloud.Web.CallCenter.Api/Relecloud.Web.CallCenter.Api.csproj
+++ b/src/Relecloud.Web.CallCenter.Api/Relecloud.Web.CallCenter.Api.csproj
@@ -1,45 +1,42 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<UserSecretsId>132c573d-ea30-413d-9176-5f0fe269d568</UserSecretsId>
-	</PropertyGroup>
-	<PropertyGroup>
-		<IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>132c573d-ea30-413d-9176-5f0fe269d568</UserSecretsId>
+  </PropertyGroup>
+  <PropertyGroup>
+    <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.1" />
-    	<PackageReference Include="Azure.Identity" Version="1.12.0" />
-		<PackageReference Include="Azure.Search.Documents" Version="11.4.0-beta.5" />
-		<PackageReference Include="Azure.Storage.Blobs" Version="12.13.1" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.12" />
-		<PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
-		<PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="3.0.0">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.1" />
-		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.1" />
+  <ItemGroup>
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
+    <PackageReference Include="Azure.Search.Documents" Version="11.6.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.3.0" />
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="8.0.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <TreatAsUsed>true</TreatAsUsed>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.8" />
     <PackageReference Include="Microsoft.Azure.StackExchangeRedis" Version="3.1.0" />
-		<PackageReference Include="Microsoft.Identity.Web" Version="1.23.0" />
-		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.1" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-	</ItemGroup>
+    <PackageReference Include="Microsoft.Identity.Web" Version="3.1.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.4" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.1" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\Relecloud.Web.Models\Relecloud.Web.Models.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Relecloud.Web.Models\Relecloud.Web.Models.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Relecloud.Web.CallCenter.Api/Startup.cs
+++ b/src/Relecloud.Web.CallCenter.Api/Startup.cs
@@ -43,7 +43,10 @@ namespace Relecloud.Web.Api
             services.AddEndpointsApiExplorer();
             services.AddSwaggerGen();
 
-            services.AddApplicationInsightsTelemetry(Configuration["App:Api:ApplicationInsights:ConnectionString"]);
+            services.AddApplicationInsightsTelemetry(options =>
+            {
+                options.ConnectionString = Configuration["App:Api:ApplicationInsights:ConnectionString"];
+            });
 
             AddAzureSearchService(services);
             AddConcertContextServices(services);
@@ -96,7 +99,7 @@ namespace Relecloud.Web.Api
             else
             {
                 // Add a concert search service based on Azure Search.
-                services.AddScoped<IConcertSearchService>(x => new AzureSearchConcertSearchService(azureSearchServiceName, sqlDatabaseConnectionString));
+                services.AddScoped<IConcertSearchService>(x => new AzureSearchConcertSearchService(azureSearchServiceName, sqlDatabaseConnectionString!));
             }
         }
 

--- a/src/Relecloud.Web.CallCenter/Program.cs
+++ b/src/Relecloud.Web.CallCenter/Program.cs
@@ -15,7 +15,7 @@ if (hasRequiredConfigSettings)
     builder.Configuration.AddAzureAppConfiguration(options =>
     {
         options
-            .Connect(new Uri(builder.Configuration["App:AppConfig:Uri"]), azureCredential)
+            .Connect(new Uri(builder.Configuration["App:AppConfig:Uri"]!), azureCredential)
             .ConfigureKeyVault(kv =>
             {
                 // Some of the values coming from Azure App Configuration are stored Key Vault, use

--- a/src/Relecloud.Web.CallCenter/Relecloud.Web.CallCenter.csproj
+++ b/src/Relecloud.Web.CallCenter/Relecloud.Web.CallCenter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>ff868c0e-c82e-4217-930f-cd0391eecc21</UserSecretsId>
@@ -12,22 +12,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
-    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="3.0.0">
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.3.0" />
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="8.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.8" />
     <PackageReference Include="Microsoft.Azure.StackExchangeRedis" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="1.25.1" />
-    <PackageReference Include="Microsoft.Identity.Web.MicrosoftGraph" Version="1.25.1" />
-    <PackageReference Include="Microsoft.Identity.Web.UI" Version="1.22.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NSwag.ApiDescription.Client" Version="13.0.5">
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Identity.Web.DownstreamApi" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="3.1.0" />
+    <PackageReference Include="NSwag.ApiDescription.Client" Version="14.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Relecloud.Web.CallCenter/Startup.cs
+++ b/src/Relecloud.Web.CallCenter/Startup.cs
@@ -42,7 +42,10 @@ namespace Relecloud.Web
             services.AddOptions();
             AddMicrosoftEntraIdServices(services);
             services.AddControllersWithViews();
-            services.AddApplicationInsightsTelemetry(Configuration["App:Api:ApplicationInsights:ConnectionString"]);
+            services.AddApplicationInsightsTelemetry(options =>
+            {
+                options.ConnectionString = Configuration["App:Api:ApplicationInsights:ConnectionString"];
+            });
 
             AddConcertContextService(services);
             AddConcertSearchService(services);
@@ -180,8 +183,8 @@ namespace Relecloud.Web
             });
 
             var builder = services.AddMicrosoftIdentityWebAppAuthentication(Configuration, "MicrosoftEntraId")
-            .EnableTokenAcquisitionToCallDownstreamApi(new string[] { })
-               .AddDownstreamWebApi("relecloud-api", Configuration.GetSection("GraphBeta"));
+                .EnableTokenAcquisitionToCallDownstreamApi(new string[] { })
+                .AddDownstreamApi("relecloud-api", Configuration.GetSection("GraphBeta"));
 
             // when using Microsoft.Identity.Web to retrieve an access token on behalf of the authenticated user
             // you should use a shared session state provider.
@@ -262,7 +265,6 @@ namespace Relecloud.Web
 
         public void Configure(WebApplication app, IWebHostEnvironment env)
         {
-
             // Configure the HTTP request pipeline.
             if (!env.IsDevelopment())
             {
@@ -294,13 +296,10 @@ namespace Relecloud.Web
 
             app.MapHealthChecks("/healthz");
 
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapControllerRoute(
-                    name: "default",
-                    pattern: "{controller=Home}/{action=Index}/{id?}");
-                endpoints.MapRazorPages();
-            });
+            app.MapControllerRoute(
+                name: "default",
+                pattern: "{controller=Home}/{action=Index}/{id?}");
+            app.MapRazorPages();
         }
     }
 }


### PR DESCRIPTION
When we brought in Microsoft.Extensions.Caching.StackExchangeRedis, it bumped the transitive version of Microsoft.IdentityModel to v7+ while before we used v6.x. There was a breaking change between these versions that switched Json.NET to System.Text.Json. However, our dependencies still used v6 of the OpenIdConnect which at runtime cannot find the new type. See https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/IdentityModel-7x#serialization-issues for details.

Easiest way to fix this is to bring in .NET 8 so the versions are all on the latest supported platforms. This brings in some required changes for downstream API access and application insights configuration.
